### PR TITLE
Show error log only when there is one

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -25,7 +25,9 @@ module.exports = (api, options, rootOptions) => {
 
       const modifiedPackageConfig = JSON.stringify(parsedConfig, null, 2);
       fs.writeFile(packageConfig, modifiedPackageConfig, (err) => {
-        api.exitLog('Something went wrong..', 'error');
+        if (!err) return;
+
+        api.exitLog(`Something went wrong.. ${err}`, 'error');
       });
     });
   }


### PR DESCRIPTION
- `exitLog` was always shown even when there were no errors
- Added actual error to `exitLog` since `Something went wrong..` isn't very informative 🙂 