### PR TITLE
Use actual project name in index and README files

### DIFF
--- a/generator/template/default/README.md
+++ b/generator/template/default/README.md
@@ -1,4 +1,4 @@
-# nsoft-template-sample
+# <%= name %>
 
 ## Project setup
 ```

--- a/generator/template/default/public/index.html
+++ b/generator/template/default/public/index.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%%= BASE_URL %%>favicon.ico">
-    <title>NSoft Sample</title>
+    <title><%= name %></title>
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but NSoft doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>We're sorry but <%= name %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
   </body>


### PR DESCRIPTION
Used `ejs` to add actual project name set by user in `index.html` and `README` templates.